### PR TITLE
not send mail if customer created from backoffice

### DIFF
--- a/Observer/SendApprovalEmail.php
+++ b/Observer/SendApprovalEmail.php
@@ -29,6 +29,10 @@ public function execute(EventObserver $observer)
 
     $customer = $observer->getCustomerDataObject();
     $customerOld = $observer->getOrigCustomerDataObject();
+        
+    // do not send mail if customer is new created from backoffice
+    if(!isset($customerOld)) return $this;
+    
     $approveAccount = (int) $customer->getCustomAttribute('approve_account')->getValue();
     $oldAppAcc = $customerOld->getCustomAttribute('approve_account');
     $approveAccountOld = isset($oldAppAcc) ? (int) $oldAppAcc->getValue(): 0;


### PR DESCRIPTION
when customer is created from backoffice, $customerOld is not defined so it throw and exception
fix issue #20 
this condition check if customer is not new, if new do not try to send mail