### PR TITLE
fix: change the post registration notice

### DIFF
--- a/Plugin/Redirect.php
+++ b/Plugin/Redirect.php
@@ -83,8 +83,7 @@ class Redirect
             $this->messageManager->getMessages(true);
 
             // Adding a custom message
-            $this->messageManager->addErrorMessage(__('Your account is not approved.
-            Kindly contact website admin for assitance.'));
+            $this->messageManager->addErrorMessage(__('Thank you for registering, your account will be reviewed shortly.'));
 
             // Destroy the customer session in order to redirect him to the login page
             $this->session->destroy();


### PR DESCRIPTION
Update the post registration message, to better convey a successful application and inform on the expected next steps.

The previous message is likely to cause confusion as to, if the registration process failed and generate unnecessary contact form submissions.